### PR TITLE
Add html and styling for inspector fields wireframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
 					</div>
 				</div>
 				<div class="main">
+					<!-- Editor Fields -->
 					<div class="fields">
 
 						<!-- New Field -->
@@ -335,6 +336,217 @@
 										</button>
 									</div>
 
+								</div>
+							</div>
+						</label>
+						<!-- End of Field -->
+
+						<!-- Add Field Button -->
+						<div class="add-field-container">
+							<button>
+								<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+									<path fill="none" d="M0 0h24v24H0V0z"/>
+									<path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/>
+								</svg>
+								Add Field
+							</button>
+						</div>
+
+					</div>
+					<!-- Insepctor Fields -->
+					<div class="fields fields--inspector">
+
+						<!-- New Field -->
+						<label class="field" ondragstart="dragStart(this, event)" ondragend="dragEnd(this)">
+							<input type="radio" name="field-selector" class="field-selector">
+							<div class="field-container">
+								<div class="field-icon-container" onmousedown="this.parentElement.parentElement.setAttribute('draggable', 'true')">
+									<svg class="field-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M21 3H3C2 3 1 4 1 5v14c0 1.1.9 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 15.92c-.02.03-.06.06-.08.08H3V5.08L3.08 5h17.83c.03.02.06.06.08.08v13.84zm-10-3.41L8.5 12.5 5 17h14l-4.5-6z"/>
+									</svg>
+									<svg class="field-grab-indicator" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+									</svg>
+								</div>
+								<span class="field-title">
+									Heading
+								</span>
+								<div class="field-copy-pill">
+									<span>heading</span>
+									<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"/>
+									</svg>
+								</div>
+							</div>
+						</label>
+						<!-- End of Field -->
+
+						<!-- New Field -->
+						<label class="field field--1/2" ondragstart="dragStart(this, event)" ondragend="dragEnd(this)">
+							<input type="radio" name="field-selector" class="field-selector" checked="checked">
+							<div class="field-container">
+								<div class="field-icon-container" onmousedown="this.parentElement.parentElement.setAttribute('draggable', 'true')">
+									<svg class="field-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M21 3H3C2 3 1 4 1 5v14c0 1.1.9 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 15.92c-.02.03-.06.06-.08.08H3V5.08L3.08 5h17.83c.03.02.06.06.08.08v13.84zm-10-3.41L8.5 12.5 5 17h14l-4.5-6z"/>
+									</svg>
+									<svg class="field-grab-indicator" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+									</svg>
+								</div>
+								<span class="field-title">
+									Heading
+								</span>
+								<div class="field-copy-pill">
+									<span>heading</span>
+									<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"/>
+									</svg>
+								</div>
+							</div>
+						</label>
+						<!-- End of Field -->
+
+						<!-- New Field -->
+						<label class="field field--1/2" ondragstart="dragStart(this, event)" ondragend="dragEnd(this)">
+							<input type="radio" name="field-selector" class="field-selector">
+							<div class="field-container">
+								<div class="field-icon-container" onmousedown="this.parentElement.parentElement.setAttribute('draggable', 'true')">
+									<svg class="field-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M21 3H3C2 3 1 4 1 5v14c0 1.1.9 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 15.92c-.02.03-.06.06-.08.08H3V5.08L3.08 5h17.83c.03.02.06.06.08.08v13.84zm-10-3.41L8.5 12.5 5 17h14l-4.5-6z"/>
+									</svg>
+									<svg class="field-grab-indicator" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+									</svg>
+								</div>
+								<span class="field-title">
+									Heading
+								</span>
+								<div class="field-copy-pill">
+									<span>heading</span>
+									<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"/>
+									</svg>
+								</div>
+							</div>
+						</label>
+						<!-- End of Field -->
+
+						<!-- New Field -->
+						<label class="field" ondragstart="dragStart(this, event)" ondragend="dragEnd(this)">
+							<input type="radio" name="field-selector" class="field-selector">
+							<div class="field-container">
+								<div class="field-icon-container" onmousedown="this.parentElement.parentElement.setAttribute('draggable', 'true')">
+									<svg class="field-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M21 3H3C2 3 1 4 1 5v14c0 1.1.9 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 15.92c-.02.03-.06.06-.08.08H3V5.08L3.08 5h17.83c.03.02.06.06.08.08v13.84zm-10-3.41L8.5 12.5 5 17h14l-4.5-6z"/>
+									</svg>
+									<svg class="field-grab-indicator" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+									</svg>
+								</div>
+								<span class="field-title">
+									Sub Heading
+								</span>
+								<div class="field-copy-pill">
+									<span>sub-heading</span>
+									<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"/>
+									</svg>
+								</div>
+							</div>
+						</label>
+						<!-- End of Field -->
+
+						<!-- New Field -->
+						<label class="field field--1/4" ondragstart="dragStart(this, event)" ondragend="dragEnd(this)">
+							<input type="radio" name="field-selector" class="field-selector">
+							<div class="field-container">
+								<div class="field-icon-container" onmousedown="this.parentElement.parentElement.setAttribute('draggable', 'true')">
+									<svg class="field-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M21 3H3C2 3 1 4 1 5v14c0 1.1.9 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 15.92c-.02.03-.06.06-.08.08H3V5.08L3.08 5h17.83c.03.02.06.06.08.08v13.84zm-10-3.41L8.5 12.5 5 17h14l-4.5-6z"/>
+									</svg>
+									<svg class="field-grab-indicator" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+									</svg>
+								</div>
+								<span class="field-title">
+									Sub Heading
+								</span>
+								<div class="field-copy-pill">
+									<span>sub-heading</span>
+									<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"/>
+									</svg>
+								</div>
+							</div>
+						</label>
+						<!-- End of Field -->
+
+						<!-- New Field -->
+						<label class="field field--3/4" ondragstart="dragStart(this, event)" ondragend="dragEnd(this)">
+							<input type="radio" name="field-selector" class="field-selector">
+							<div class="field-container">
+								<div class="field-icon-container" onmousedown="this.parentElement.parentElement.setAttribute('draggable', 'true')">
+									<svg class="field-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M21 3H3C2 3 1 4 1 5v14c0 1.1.9 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 15.92c-.02.03-.06.06-.08.08H3V5.08L3.08 5h17.83c.03.02.06.06.08.08v13.84zm-10-3.41L8.5 12.5 5 17h14l-4.5-6z"/>
+									</svg>
+									<svg class="field-grab-indicator" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+									</svg>
+								</div>
+								<span class="field-title">
+									Sub Heading
+								</span>
+								<div class="field-copy-pill">
+									<span>sub-heading</span>
+									<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"/>
+									</svg>
+								</div>
+							</div>
+						</label>
+						<!-- End of Field -->
+
+						<!-- New Field -->
+						<label class="field field--1/2" ondragstart="dragStart(this, event)" ondragend="dragEnd(this)">
+							<input type="radio" name="field-selector" class="field-selector">
+							<div class="field-container">
+								<div class="field-icon-container" onmousedown="this.parentElement.parentElement.setAttribute('draggable', 'true')">
+									<svg class="field-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M21 3H3C2 3 1 4 1 5v14c0 1.1.9 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 15.92c-.02.03-.06.06-.08.08H3V5.08L3.08 5h17.83c.03.02.06.06.08.08v13.84zm-10-3.41L8.5 12.5 5 17h14l-4.5-6z"/>
+									</svg>
+									<svg class="field-grab-indicator" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+									</svg>
+								</div>
+								<span class="field-title">
+									Sub Heading
+								</span>
+								<div class="field-copy-pill">
+									<span>sub-heading</span>
+									<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+										<path fill="none" d="M0 0h24v24H0V0z"/>
+										<path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"/>
+									</svg>
 								</div>
 							</div>
 						</label>

--- a/style.css
+++ b/style.css
@@ -69,8 +69,9 @@ body {
     grid-column: 1 / 2;
     grid-row: 2 / 3;
     display: flex;
-    justify-content: center;
-    align-items: flex-start;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
     padding-top: 50px;
 }
 
@@ -87,6 +88,11 @@ body {
     display: grid;
     grid-template-columns: repeat( 4, calc( 25% - 15px ) );
     grid-gap: 20px;
+    margin-bottom: 60px;
+}
+
+.fields--inspector {
+    max-width: 280px;
 }
 
 .field-selector {
@@ -127,6 +133,11 @@ body {
     cursor: ew-resize;
 }
 
+.fields--inspector .field--1\/4,
+.fields--inspector .field--1\/2,
+.fields--inspector .field--3\/4 {
+    grid-column: 1 / 5;
+}
 .field:not(.sub-field)::after {
     content: '';
     position: absolute;
@@ -250,6 +261,14 @@ body {
 }
 
 .field--1\/4 .field-copy-pill svg {
+    margin-left: 0;
+}
+
+.fields--inspector .field-copy-pill span {
+    display: none;
+}
+
+.fields--inspector .field-copy-pill svg {
     margin-left: 0;
 }
 


### PR DESCRIPTION
I've added the HTML and styling for the inspector version of the wireframe. For now this just sits under the Editor wireframe. Once we add the Editor/Inspector toggles we can shift this markup accordingly.